### PR TITLE
Fixed overflowing waiting list position/activity display in course card.

### DIFF
--- a/training/templates/components/lists/course_card.html
+++ b/training/templates/components/lists/course_card.html
@@ -1,5 +1,5 @@
 {% load tags %}
-<div class="bg-base-100 rounded-xl shadow-md border semantic-neutral-border overflow-visible hover:shadow-lg transition-shadow"
+<div class="bg-base-100 rounded-xl shadow-md border semantic-neutral-border overflow-hidden hover:shadow-lg transition-shadow"
      data-course
      data-type="{{ course.type }}"
      data-position="{{ course.position }}"


### PR DESCRIPTION
Replaced `overflow-visible` class with `overflow-hidden` in course_card.html outer div.

Possible fix for #141 